### PR TITLE
docs: Add 6th fest status board

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 ## 축하합니다! 제 6회 D2 CAMPUS FEST 결승진출팀 안내
 
+**[프로젝트 소개 및 진행 현황판](https://d2campusfest6th-2019.herokuapp.com/)**
+
 프로젝트|설명|라이선스
 -|-|-
 [aws-interface](https://github.com/hubaimaster/aws-interface)|클라우드 서비스 추상화 인터페이스 제공|Apache-2.0|


### PR DESCRIPTION
2019 d2 fest finalist 소개 및 진행 현황판을 만들게 되어 공유합니다! 과거 이력 수정까지 기록에 포함되고 commit과 issue에 대한 정보만 나타나 객관적인 지표는 아니지만, 대회의 진행 상황을 실시간으로 보면 좋을 것 같아서 만들었습니다!

이 리퀘스트를 통해 README에 임의로 적었지만, 따로 수정해서 사용하셔도 좋아요!

url: https://d2campusfest6th-2019.herokuapp.com/
repo: https://github.com/rayleighko/d2CampusFest6th-2019

![screen shot 2019-01-21 at 03 01 47](https://user-images.githubusercontent.com/24822072/51443221-ec305a80-1d28-11e9-9773-1600a45f47b9.png)

